### PR TITLE
fix: Add Azure Stack HCI 23H2 kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ class WindowsFlavour(Enum):
     WindowsServer2016 = "Microsoft Windows Server 2016"     # Windows-10.0.14393
     WindowsServer2019 = "Microsoft Windows Server 2019"     # Windows-10.0.17763
     WindowsServer2022 = "Microsoft Windows Server 2022"     # Windows-10.0.20348
+    WindowsServer2025 = "Microsoft Windows Server 2025"     # Windows-10.0.26100
     WindowsServer2022H2 = "Microsoft Windows Server 2022 H2"   # Windows-10.0.22621
+    AzureStackHCI22H2 = "Microsoft Azure Stack HCI 22H2"  # Windows-10.0.20349
+    AzureStackHCI23H2 = "Microsoft Azure Stack HCI 23H2"  # Windows-10.0.25398
+    AzureStackHCI24H2 = "Microsoft Azure Stack HCI 24H2"  # Windows-10.0.26100
 
 ```
 

--- a/mfd_typing/os_values.py
+++ b/mfd_typing/os_values.py
@@ -16,7 +16,7 @@ class WindowsFlavour(Enum):
     WindowsServer2022H2 = "Microsoft Windows Server 2022 H2"  # Windows-10.0.22621
     WindowsServer2025 = "Microsoft Windows Server 2025"  # Windows-10.0.26100
     AzureStackHCI22H2 = "Azure Stack HCI 22H2"  # Windows-10.0.20349
-    AzureStackHCI23H2 = "Azure Stack HCI 23H2"  # Windows-10.0.22631
+    AzureStackHCI23H2 = "Azure Stack HCI 23H2"  # Windows-10.0.25398
     AzureStackHCI24H2 = "Azure Stack HCI 24H2"  # Windows-10.0.26100
 
 

--- a/mfd_typing/utils.py
+++ b/mfd_typing/utils.py
@@ -229,6 +229,8 @@ def get_windows_version_from_kernel(kernel_version: str) -> WindowsFlavour:
         return WindowsFlavour.WindowsServer2022
     elif kernel_version == 22621:
         return WindowsFlavour.WindowsServer2022H2
+    elif kernel_version == 25398:
+        return WindowsFlavour.AzureStackHCI23H2
     elif kernel_version == 26100:
         return WindowsFlavour.WindowsServer2025
     else:

--- a/tests/unit/test_mfd_typing/test_utils.py
+++ b/tests/unit/test_mfd_typing/test_utils.py
@@ -105,6 +105,11 @@ class Testutils:
         expected_windows_version = WindowsFlavour.WindowsServer2016
         assert utils.get_windows_version_from_kernel(kernel_version=kernel_version) == expected_windows_version
 
+    def test_get_windows_version_from_kernel_pass_ashci23h2(self):
+        kernel_version = "25398"
+        expected_windows_version = WindowsFlavour.AzureStackHCI23H2
+        assert utils.get_windows_version_from_kernel(kernel_version=kernel_version) == expected_windows_version
+
     def test_get_windows_version_from_kernel_invalid(self):
         kernel_version = "14393-bla"
         with pytest.raises(InvalidWindowsKernelError):


### PR DESCRIPTION
This pull request adds support for detecting the Azure Stack HCI 23H2 Windows flavour based on the kernel version in the `get_windows_version_from_kernel` function.

Windows version detection:

* Updated `get_windows_version_from_kernel` in `mfd_typing/utils.py` to return `WindowsFlavour.AzureStackHCI23H2` when the kernel version is `25398`.

Fixes intel#6