### PR TITLE
feat: Add function to map Windows System Info to Windows Flavour with…

### DIFF
--- a/mfd_typing/utils.py
+++ b/mfd_typing/utils.py
@@ -5,7 +5,7 @@
 from typing import Union, TYPE_CHECKING
 from netaddr import ipv6_verbose
 from mfd_typing.exceptions import UnknownWindowsKernelVersionError, InvalidWindowsKernelError
-from mfd_typing.os_values import WindowsFlavour
+from mfd_typing.os_values import SystemInfo, WindowsFlavour
 import re
 
 if TYPE_CHECKING:
@@ -233,6 +233,31 @@ def get_windows_version_from_kernel(kernel_version: str) -> WindowsFlavour:
         return WindowsFlavour.WindowsServer2025
     else:
         raise UnknownWindowsKernelVersionError(f"Cannot map {kernel_version} to any of supported Windows Flavours.")
+
+
+def get_windows_version_from_system_info(system_info: SystemInfo) -> WindowsFlavour:
+    """
+    Map Windows System Info to Windows Flavour.
+
+    Using kernel version + os name to determine the exact Windows Flavour.
+
+    :param system_info: SystemInfo object
+    :return: Windows OS Version
+    """
+    kernel_version_str = system_info.kernel_version
+    try:
+        kernel_version = int(kernel_version_str)
+    except ValueError:
+        raise InvalidWindowsKernelError(f"Cannot convert '{kernel_version_str}' to integer.")
+
+    if kernel_version == 26100:
+        if system_info.os_name is None:
+            raise UnknownWindowsKernelVersionError(f"Cannot map {kernel_version} to any of supported Windows Flavours.")
+        return (
+            WindowsFlavour.WindowsServer2025 if "Windows" in system_info.os_name else WindowsFlavour.AzureStackHCI24H2
+        )
+    else:
+        return get_windows_version_from_kernel(kernel_version_str)
 
 
 def strtobool(param: Union[str, bool]) -> bool:

--- a/tests/unit/test_mfd_typing/test_utils.py
+++ b/tests/unit/test_mfd_typing/test_utils.py
@@ -115,6 +115,40 @@ class Testutils:
         with pytest.raises(UnknownWindowsKernelVersionError):
             utils.get_windows_version_from_kernel(kernel_version=kernel_version)
 
+    def test_get_windows_version_from_system_info_pass_16(self):
+        system_info = utils.SystemInfo()
+        system_info.kernel_version = "14393"
+        expected_windows_version = WindowsFlavour.WindowsServer2016
+        assert utils.get_windows_version_from_system_info(system_info=system_info) == expected_windows_version
+
+    def test_get_windows_version_from_system_info_pass_2025(self):
+        system_info = utils.SystemInfo()
+        system_info.kernel_version = "26100"
+        system_info.os_name = "Microsoft Windows Server 2025 Standard"
+        expected_windows_version = WindowsFlavour.WindowsServer2025
+        assert utils.get_windows_version_from_system_info(system_info=system_info) == expected_windows_version
+
+    def test_get_windows_version_from_system_info_pass_AzureStackHCI24H2(self):
+        system_info = utils.SystemInfo()
+        system_info.kernel_version = "26100"
+        system_info.os_name = "Azure Stack HCI 24H2"
+        expected_windows_version = WindowsFlavour.AzureStackHCI24H2
+        assert utils.get_windows_version_from_system_info(system_info=system_info) == expected_windows_version
+
+    def test_get_windows_version_from_system_info_invalid(self):
+        system_info = utils.SystemInfo()
+        system_info.kernel_version = "14393-bla"
+        system_info.os_name = "Microsoft Windows Server 2025 Standard"
+        with pytest.raises(InvalidWindowsKernelError):
+            utils.get_windows_version_from_system_info(system_info=system_info)
+
+    def test_get_windows_version_from_system_info_unknown(self):
+        system_info = utils.SystemInfo()
+        system_info.kernel_version = "14392"
+        system_info.os_name = "Microsoft Windows Server 2025 Standard"
+        with pytest.raises(UnknownWindowsKernelVersionError):
+            utils.get_windows_version_from_system_info(system_info=system_info)
+
     @pytest.mark.parametrize("param", ["yes", "YES", "true", "TRUE", "1", "y", "t", True])
     def test_strtobool_true(self, param):
         assert utils.strtobool(param)


### PR DESCRIPTION
This pull request adds a new utility function to map Windows system information to a Windows version and introduces comprehensive unit tests for this functionality. The changes also include a minor import update to support the new logic.

**New functionality for Windows version mapping:**

* Added a new function `get_windows_version_from_system_info` in `utils.py` to map a `SystemInfo` object (containing kernel version and OS name) to a `WindowsFlavour` enum, with error handling for unknown or invalid kernel versions.
* Updated imports in `utils.py` to include `SystemInfo` for the new functionality.

**Testing improvements:**

* Added unit tests in `test_utils.py` to cover all major code paths of `get_windows_version_from_system_info`, including successful mappings, invalid kernel versions, and unknown kernel versions.
* Minor import addition in `test_utils.py` to support new tests.